### PR TITLE
Add 'auth_token' param to two Datapoint examples in API Docs

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -817,7 +817,7 @@ A Datapoint belongs to a [Goal](#goal), which has many Datapoints.
 > Examples
 
 ```json
-  GET /api/v1/users/alice/goals/weight/datapoints.json
+  GET /api/v1/users/alice/goals/weight/datapoints.json?auth_token=yourtoken
 
   [{"id":"1", "timestamp":1234567890, "daystamp":"20090213", "value":7, "comment":"", "updated_at":123, "requestid":"a"},
    {"id":"2", "timestamp":1234567891, "daystamp":"20090214", "value":8, "comment":"", "updated_at":123, "requestid":"b"}]

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -843,7 +843,7 @@ The list of [Datapoint](#datapoint) objects.
 > Examples
 
 ```json
-  POST /api/v1/users/alice/goals/weight/datapoints.json?timestamp=1325523600&value=130.1&comment=sweat+a+lot+today
+  POST /api/v1/users/alice/goals/weight/datapoints.json?auth_token=yourtoken&timestamp=1325523600&value=130.1&comment=sweat+a+lot+today
 
   { "timestamp": 1325523600,
     "daystamp": "20120102",


### PR DESCRIPTION
Hi Beeminder~

I was playing around with the Beeminder API today while referring to the API docs and I noticed that under the **Datapoint Resource** section the example endpoints for *Get all the datapoints* and *Create a datapoint* are missing the parameter `auth_token=...`

I therefore added this param to these two examples. If you accept this PR I will also go ahead and edit the remaining examples under this section.

Thanks,
Jun