### PR TITLE
remove issue template used by Slate

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,0 @@
-If this is a question or feature request, make sure to:
-
-- [ ] The title starts with `Question:` or `Feature:`.
-
-If this is an bug report, not a question, make sure to:
-
-- [ ] I'm not running Windows (which is unsupported), or if I am, I can confirm this issue appears on another platform, or Vagrant.
-- [ ] I've included my browser and Ruby version in this issue.


### PR DESCRIPTION
not needed and misleading for Beeeminder

Second part is clearly bogus for Beeminder.

Though maybe you want to keep "If this is a question or feature request, make sure to: The title starts with Question: or Feature:." part.