### PR TITLE
Document the tags field on the goal resource

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -444,7 +444,7 @@ Allowed range is -17*3600 to 6*3600 (7am to 6am).
 * `integery` (boolean): Assume that the units must be integer values.  Used for things like `limsum`.
 * `gunits` (string): Goal units, like "hours" or "pushups" or "pages".
 * `hhmmformat` (boolean): Whether to show data in a "timey" way, with colons.  For example, this would make a 1.5 show up as 1:30.
-* `todayta` (boolean): Whether there are any datapoints for today
+* `todayta` (boolean): Whether there are any datapoints for today.
 * `tags` (array): A list of the goals's tags.
 
 The goal types are shorthand for a collection of settings of more fundamental goal attributes.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -445,6 +445,7 @@ Allowed range is -17*3600 to 6*3600 (7am to 6am).
 * `gunits` (string): Goal units, like "hours" or "pushups" or "pages".
 * `hhmmformat` (boolean): Whether to show data in a "timey" way, with colons.  For example, this would make a 1.5 show up as 1:30.
 * `todayta` (boolean): Whether there are any datapoints for today
+* `tags` (array): A list of the goals's tags.
 
 The goal types are shorthand for a collection of settings of more fundamental goal attributes.
 Note that changing the goal type of an already-created goal has no effect on those fundamental goal attributes.


### PR DESCRIPTION
This documents the `tags` field added in https://github.com/beeminder/beeminder/pull/2158.