### PR TITLE
Fix pluralizations in tags API docs

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -673,7 +673,7 @@ Create a new goal for user *u*.
 * \[`datapublic`\] (boolean)
 * \[`datasource`\] (string): one of {"api", "ifttt", "zapier", or `clientname`\}. Default: none (i.e., "manual").
 * \[`dryrun`\] (boolean). Pass this to test the endpoint without actually creating a goal. Defaults to false.
-* \[`tags`\] (array). An optional list of tags to add to the new goal. Each tag must be an alphanumeric strings.
+* \[`tags`\] (array). An optional list of tags to add to the new goal. Each tag must be an alphanumeric string.
 
 [Exactly](http://youtu.be/QM9Bynjh2Lk?t=4m14s) two out of three of `goaldate`, `goalval`, and `rate` are required.
 
@@ -741,7 +741,7 @@ To change any of {`goaldate`, `goalval`, `rate`} use `roadall`.
 * \[`datasource`\] (string): one of {"api", "ifttt", "zapier", or `clientname`\}. Default: none.
   * If you pass in your API client's registered name for the `datasource`, and your client has a registered `autofetch_callback_url`, we will POST to your callback when this goal wants new data, as outlined in [Client OAuth](#6-optional-autofetch-callback ).
   * To unset the datasource, (i.e., return to manual entry) pass in the empty string `""`.
-* \[`tags`\] (array). A list of tags for the goal. Each tag must be an alphanumeric strings. NOTE: if you pass this parameter, it will replace the existing tags for the goal. If you pass an empty array, or an explicit nil value, it will remove all tags from the goal. 
+* \[`tags`\] (array). A list of tags for the goal. Each tag must be an alphanumeric string. NOTE: if you pass this parameter, it will replace the existing tags for the goal. If you pass an empty array, or an explicit nil value, it will remove all tags from the goal. 
 
 ### Returns
 


### PR DESCRIPTION
I see that you already added API docs for the tags API changes, but here's a small typo fix.