### PR TITLE
add missing end backslash to multi-line curl commands

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -992,7 +992,7 @@ The list of [Datapoint](#datapoint) objects.
 > Examples
 
 ```shell
-  curl -X POST https://www.beeminder.com/api/v1/users/alice/goals/weight/datapoints.json
+  curl -X POST https://www.beeminder.com/api/v1/users/alice/goals/weight/datapoints.json \
     -d auth_token=abc123 \
     -d timestamp=1325523600 \
     -d value=130.1 \
@@ -1039,7 +1039,7 @@ The updated [Datapoint](#datapoint) object.
 > Examples
 
 ```shell
-  curl -X POST https://www.beeminder.com/api/v1/users/alice/goals/weight/datapoints/create_all.json
+  curl -X POST https://www.beeminder.com/api/v1/users/alice/goals/weight/datapoints/create_all.json \
     -d auth_token=abc123 \
     -d datapoints=[{"timestamp":1343577600,"value":220.6,"comment":"blah+blah", "requestid":"abcd182475929"}, {"timestamp":1343491200,"value":220.7, "requestid":"abcd182475930"}]
 ```


### PR DESCRIPTION
Adjusts the two example curl commands shown below so that they have a backslash at the end of the first line.

I have NOT tried to compile this because so much effort for such a tiny change, but shout if you want me to before considering this for merging.

https://api.beeminder.com/#postdata
"Create a datapoint"
![Screenshot from 2022-07-02 17-51-15](https://user-images.githubusercontent.com/1495809/176991970-81da59bd-565b-4472-91ba-5ee84ad11e69.png)

https://api.beeminder.com/#postdatas
"Create multiple datapoints"
![Screenshot from 2022-07-02 17-51-08](https://user-images.githubusercontent.com/1495809/176991973-50ee3b37-e6e1-494e-9a08-f82206a58dc9.png)
