### PR TITLE
Fix ratchet endpoint docs: do-less semantics, flat-spot clamp, typo

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -972,6 +972,7 @@ The updated [Goal](#goal) object.
 <h2 id="unclebutton">Call "Uncle" (i.e. instant derail)</h2>
 
 > Example
+
 ```shell
   curl https://www.beeminder.com/api/v1/users/alice/goals/blah/uncleme.json?auth_token=abc123
 ```
@@ -1026,6 +1027,7 @@ The updated [Goal](#goal) object, or an error if the goal is not red.
 <h2 id="ratchet">Ratchet a goal</h2>
 
 > Example
+
 ```shell
   # Ratchet a do-more goal down to 2 days of safety buffer
   curl -X POST https://www.beeminder.com/api/v1/users/alice/goals/exercise/ratchet.json \

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1034,7 +1034,8 @@ The updated [Goal](#goal) object, or an error if the goal is not red.
     -d auth_token=abc123 \
     -d newsafety=2
 
-  # Ratchet a do-less goal down to 3 units of buffer (the gap to the bright red line)
+  # Ratchet a do-less goal down to 3 *units* of safety buffer (distance below
+  # the bright red line)
   curl -X POST https://www.beeminder.com/api/v1/users/alice/goals/junkfood/ratchet.json \
     -d auth_token=abc123 \
     -d newsafety=3
@@ -1080,15 +1081,15 @@ Ratcheting is useful when you have built up a large safety buffer and want to co
 
 * **Do More / Odometer / Gain Weight goals**: `newsafety` represents the number of **days of safety buffer** you want to ratchet down to. For example, `newsafety=2` means you'll have 2 days of buffer after ratcheting.
 
-* **Do Less / Whittle Down goals**: `newsafety` represents the number of **units of safety buffer** you want to ratchet down to — that is, the gap (in the goal's units, e.g. cigarettes or dollars) between your current total and the bright red line. For example, `newsafety=3` means you'll have 3 units of buffer before you derail. Note that this is a delta relative to the bright red line, **not** your absolute hard-cap total.
+* **Do Less / Whittle Down goals**: `newsafety` specifies the number of **units of safety buffer** you want to ratchet down to. Namely, the distance, as measured in the goal's units (e.g., cigarettes or dollars), between your current total and the bright red line. For example, if your current hard cap is +10 cigarettes and you pass `newsafety=5`, you'll have a hard cap of +5 cigarettes, aka 5 units of buffer before you derail. (Note that the number is relative to the bright red line, not the absolute hard-cap total.)
 
 ### Parameters
 
-* `newsafety` (number, required): Target safety buffer to ratchet down to — in days of buffer for do-more goals, or units of buffer for do-less goals. Must be between 0 and the current maximum ratchetable amount. The meaning depends on goal type (see above).
+* `newsafety` (number, required): Target safety buffer to ratchet down to, given as days of buffer for do-more goals, or units of buffer for do-less goals. Must be between 0 and the current maximum ratchetable amount. The meaning depends on goal type (see above).
 * \[`beemergency`\] (boolean or string): Required when `newsafety=0`. Must be `true`, `"true"`, or `"True"`. This is a safety mechanism to prevent accidentally ratcheting to beemergency (zero days of buffer or zero hard cap).
 
 <aside class="notice">
-If the goal is currently on a flat spot (for example, a scheduled break starting tomorrow), <code>newsafety</code> is clamped to a minimum of 1 day: ratcheting cannot push you into a beemergency while you're on a break. The request still returns <code>200</code> with the updated goal, but the resulting buffer may be larger than the <code>newsafety</code> you requested — in particular, <code>newsafety=0</code> with <code>beemergency=true</code> will leave you with 1 day of buffer, not 0. Ratchet again to further shorten the break.
+If the goal is currently on a flat spot (such as a scheduled break starting tomorrow), <code>newsafety</code> is clamped to a minimum of 1 day: ratcheting cannot push you into a beemergency while you're on a break. The request still returns <code>200</code> with the updated goal, but the resulting buffer may be larger than the <code>newsafety</code> you requested. In particular, <code>newsafety=0</code>, even with <code>beemergency=true</code>, would leave you with 1 day of buffer, not 0, when you're on flat spot. Ratchet again to further shorten the break.
 </aside>
 
 ### Returns

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1032,7 +1032,7 @@ The updated [Goal](#goal) object, or an error if the goal is not red.
     -d auth_token=abc123 \
     -d newsafety=2
 
-  # Ratchet a do-less goal down to 3 units of hard cap
+  # Ratchet a do-less goal down to 3 units of buffer (the gap to the bright red line)
   curl -X POST https://www.beeminder.com/api/v1/users/alice/goals/junkfood/ratchet.json \
     -d auth_token=abc123 \
     -d newsafety=3
@@ -1078,12 +1078,16 @@ Ratcheting is useful when you have built up a large safety buffer and want to co
 
 * **Do More / Odometer / Gain Weight goals**: `newsafety` represents the number of **days of safety buffer** you want to ratchet down to. For example, `newsafety=2` means you'll have 2 days of buffer after ratcheting.
 
-* **Do Less / Whittle Down goals**: `newsafety` represents the **hard cap value in goal units** (e.g., cigarettes, dollars, etc.) that you want to ratchet down to. For example, if your current hard cap is 10 cigarettes and you pass `newsafety=5`, you'll have a hard cap of 5 cigarettes.
+* **Do Less / Whittle Down goals**: `newsafety` represents the number of **units of safety buffer** you want to ratchet down to — that is, the gap (in the goal's units, e.g. cigarettes or dollars) between your current total and the bright red line. For example, `newsafety=3` means you'll have 3 units of buffer before you derail. Note that this is a delta relative to the bright red line, **not** your absolute hard-cap total.
 
 ### Parameters
 
-* `newsafety` (number, required): Target safety buffer/hard cap to ratchet down to. Must be between 0 and the current maximum ratchetable amount. The meaning depends on goal type (see above).
+* `newsafety` (number, required): Target safety buffer to ratchet down to — in days of buffer for do-more goals, or units of buffer for do-less goals. Must be between 0 and the current maximum ratchetable amount. The meaning depends on goal type (see above).
 * \[`beemergency`\] (boolean or string): Required when `newsafety=0`. Must be `true`, `"true"`, or `"True"`. This is a safety mechanism to prevent accidentally ratcheting to beemergency (zero days of buffer or zero hard cap).
+
+<aside class="notice">
+If the goal is currently on a flat spot (for example, a scheduled break starting tomorrow), <code>newsafety</code> is clamped to a minimum of 1 day: ratcheting cannot push you into a beemergency while you're on a break. The request still returns <code>200</code> with the updated goal, but the resulting buffer may be larger than the <code>newsafety</code> you requested — in particular, <code>newsafety=0</code> with <code>beemergency=true</code> will leave you with 1 day of buffer, not 0. Ratchet again to further shorten the break.
+</aside>
 
 ### Returns
 
@@ -1096,7 +1100,7 @@ The updated [Goal](#goal) object.
 * "newsafety cannot be negative" - Negative value not allowed
 * "newsafety cannot exceed X" - Requested value exceeds maximum ratchetable amount
 * "Ratcheting to 0 days of buffer requires beemergency=True on the API call" - Safety parameter missing for zero ratchet
-* "Goal cannot be ratched because it is non-monotonic in the next N days" - Goal is not in a ratchetable state
+* "Goal cannot be ratcheted because it is non-monotonic in the next N days" - Goal is not in a ratchetable state
 * "Goal cannot be ratcheted (may be archived, ended, or have no buffer)" - Goal is not in a ratchetable state
 * "Failed to ratchet goal" - Ratchet operation failed
 


### PR DESCRIPTION
Reconciles the **Ratchet a goal** docs against the actual API implementation (`api/v1/goals_controller.rb` + the `Goal` model methods it calls in the beeminder repo), plus fixes a couple of broken example code blocks.

### 1. Do-less `newsafety` semantics were misleading
The docs described `newsafety` for do-less goals as the **absolute hard-cap value** ("current hard cap is 10 cigarettes → `newsafety=5` → hard cap of 5"). In the code it's actually the **buffer delta relative to the bright red line**:
- `ratchet_upper_limit` bounds it by the current `delta` (`|delta|`), i.e. your current buffer — not your total cap.
- `moveRoadByYAxis` treats it as the new delta (`newdelta = newsafety * -1` for WEEN), positioning the new red-line edge at `vcur ± newsafety` — a margin measured from your current total, not a fixed coordinate. The model comment is explicit: *"we ask you for the new cap, like +6, which is a delta' of -6 … delta relative to the road."*

Rewrote the bullet, the curl comment, and the parameter description to frame it as units of buffer.

### 2. Flat-spot clamp was undocumented
When a goal is on a flat spot (e.g. a scheduled break starting tomorrow), the controller routes to `ratchetflat([1, newsafety].max)`, flooring buffer at 1 day. So `newsafety=0` + `beemergency=true` on a break returns `200` but leaves **1 day of buffer, not a beemergency** — with nothing in the response to signal the clamp. Added a `notice` aside documenting this.

### 3. Typo in the non-monotonic error string
Docs said `"Goal cannot be ratched…"`; the controller emits `"Goal cannot be ratcheted…"`. Fixed so clients matching on the error text don't miss it.

### 4. Fixed broken shell example blocks (Ratchet + Call "Uncle")
In both sections, `> Example` sat directly against the opening ` ```shell ` fence with no blank line, so Redcarpet folded the fence into the blockquote paragraph instead of opening a code block — it rendered as prose with literal backticks leaking onto the page. Added a blank line in each to restore the highlighted shell block.

Verified locally by building the Slate site and confirming each section renders as a proper highlighted code block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)